### PR TITLE
chore: add package support metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,10 @@
     "Prettier config"
   ],
   "repository": "https://github.com/VKCOM/prettier-config",
+  "homepage": "https://github.com/VKCOM/prettier-config#readme",
+  "bugs": {
+    "url": "https://github.com/VKCOM/prettier-config/issues"
+  },
   "peerDependencies": {
     "prettier": "^3.0.0"
   },


### PR DESCRIPTION
## Summary
- add npm package homepage metadata pointing to the repository README
- add a bugs URL pointing to the repository issue tracker

## Validation
- checked package metadata with a Node assertion for name, homepage, and bugs URL
- `npm pack --dry-run --ignore-scripts --json`
- `git diff --check`
