### PR TITLE
fix: add missing metadata fields to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@vkontakte/prettier-config",
   "version": "0.2.1",
+  "homepage": "https://github.com/VKCOM/prettier-config",
+  "bugs": {
+    "url": "https://github.com/VKCOM/prettier-config/issues"
+  },
   "license": "MIT",
   "description": "Prettier config from VK",
   "main": "index.js",


### PR DESCRIPTION
Adds missing `bugs, homepage` metadata to `package.json`.